### PR TITLE
🪲 Fix issues with contacts table and breadcrumbs

### DIFF
--- a/src/components/ContactsTable/index.tsx
+++ b/src/components/ContactsTable/index.tsx
@@ -206,7 +206,9 @@ const ContactsTable: FC = () => {
                       sx={{
                         height: '100%',
                         width: '100%',
-                        position: 'relative',
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
                       }}
                     >
                       <Box

--- a/src/pages/contacts/[contactId].tsx
+++ b/src/pages/contacts/[contactId].tsx
@@ -100,7 +100,7 @@ const ContactDetails: React.FC = () => {
       </Head>
       <Container
         sx={{
-          padding: '1.25rem',
+          padding: '0 1.25rem 1.25rem',
           display: 'flex',
           gap: '0.5rem',
           flexDirection: 'column',

--- a/src/pages/contacts/edit/[contactId].tsx
+++ b/src/pages/contacts/edit/[contactId].tsx
@@ -133,7 +133,7 @@ const UpdateContactForm: React.FC = () => {
               <IconButton onClick={() => router.push('/')}>
                 <Home />
               </IconButton>
-              <Typography color='text.primary'>Contact</Typography>
+              <Typography color='text.primary'>Contact's Detail</Typography>
               <Button
                 color='primary'
                 variant='text'


### PR DESCRIPTION
- The loader for the contacts table was not in the correct location, resulting in inconsistent display. This issue is resolved by moving the loader to the correct location.
- There were two issues with the breadcrumbs. First, the margin was incorrect on every view, causing inconsistency in the display. This issue is fixed by updating the margin.
- Second, the title for the breadcrumb section in the contact details view was incorrect. This issue is resolved by updating the title.