### PR TITLE
🪲 Fix contacts table min-height on mobile

### DIFF
--- a/src/components/ContactsTable/index.tsx
+++ b/src/components/ContactsTable/index.tsx
@@ -184,7 +184,10 @@ const ContactsTable: FC = () => {
             mb: 2,
             borderRadius: '1rem',
             height: '100%',
-            maxHeight: 'calc(100vh - 250px)',
+            maxHeight: {
+              xs: 'calc(100vh - 250px)',
+              md: 'calc(100vh - 200px)',
+            },
             overflow: 'auto',
           }}
         >

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -52,6 +52,7 @@ export default function ResponsiveDrawer(props: Props) {
         sx={{
           display: { sm: 'block', md: 'flex' },
           backgroundColor: '#f5f5f5',
+          minHeight: '100vh',
         }}
         component='section'
       >
@@ -165,8 +166,6 @@ export default function ResponsiveDrawer(props: Props) {
               width: '100%',
               maxWidth: { xs: '100%', md: '72rem' },
               position: 'relative',
-
-              minHeight: '100vh',
             }}
           >
             {props.children}


### PR DESCRIPTION
- Fix defaultLayout background color, not fully expanding vertically.